### PR TITLE
Remove unwanted shadow of tab icon

### DIFF
--- a/lib/circular_bottom_navigation.dart
+++ b/lib/circular_bottom_navigation.dart
@@ -152,10 +152,21 @@ class _CircularBottomNavigationState extends State<CircularBottomNavigation>
       child: Container(
         width: widget.circleSize,
         height: widget.circleSize,
-        decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: widget.tabItems[selectedPos].color,
-            border: Border.all(width: widget.circleStrokeWidth, color: widget.barBackgroundColor)),
+        child: Stack(
+          children: <Widget>[
+            Container(
+              decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: widget.barBackgroundColor),
+            ),
+            Container(
+              margin: EdgeInsets.all(widget.circleStrokeWidth),
+              decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: widget.tabItems[selectedPos].color),
+            ),
+          ],
+        ),
       ),
       left: (selectedPosAnimation.value * sectionsWidth) +
           (sectionsWidth / 2) -


### PR DESCRIPTION
According to the artwork in [Uplabs ](https://www.uplabs.com/posts/bottom-tab) the icons must have no shadow and follow the flat colors.
So I removed it and you can see the changes here:
![Screenshot_2019-08-15-06-00-42](https://user-images.githubusercontent.com/8822586/63067239-35ddce00-bf23-11e9-8602-81baee5336ec.png)
