### PR TITLE
Remove unwanted shadow and Add TextStyle for Tab label

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,8 +53,8 @@ import 'package:circular_bottom_navigation/tab_item.dart';
 ### Make your TabItems
 ```kotlin
 List<TabItem> tabItems = List.of([
-    new TabItem(Icons.home, "Home", Colors.blue),
-    new TabItem(Icons.search, "Search", Colors.orange),
+    new TabItem(Icons.home, "Home", Colors.blue, labelStyle: TextStyle(fontWeight: FontWeight.normal)),
+    new TabItem(Icons.search, "Search", Colors.orange, labelStyle: TextStyle(color: Colors.red, fontWeight: FontWeight.bold)),
     new TabItem(Icons.layers, "Reports", Colors.red),
     new TabItem(Icons.notifications, "Notifications", Colors.cyan),
   ]);

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -31,8 +31,8 @@ class _MyHomePageState extends State<MyHomePage> {
   double bottomNavBarHeight = 60;
 
   List<TabItem> tabItems = List.of([
-    new TabItem(Icons.home, "Home", Colors.blue),
-    new TabItem(Icons.search, "Search", Colors.orange),
+    new TabItem(Icons.home, "Home", Colors.blue, labelStyle: TextStyle(fontWeight: FontWeight.normal)),
+    new TabItem(Icons.search, "Search", Colors.orange, labelStyle: TextStyle(color: Colors.red, fontWeight: FontWeight.bold)),
     new TabItem(Icons.layers, "Reports", Colors.red),
     new TabItem(Icons.notifications, "Notifications", Colors.cyan),
   ]);
@@ -58,7 +58,7 @@ class _MyHomePageState extends State<MyHomePage> {
   }
 
   Widget bodyContainer() {
-    Color selectedColor = tabItems[selectedPos].color;
+    Color selectedColor = tabItems[selectedPos].circleColor;
     String slogan;
     switch (selectedPos) {
       case 0:

--- a/lib/circular_bottom_navigation.dart
+++ b/lib/circular_bottom_navigation.dart
@@ -152,10 +152,21 @@ class _CircularBottomNavigationState extends State<CircularBottomNavigation>
       child: Container(
         width: widget.circleSize,
         height: widget.circleSize,
-        decoration: BoxDecoration(
-            shape: BoxShape.circle,
-            color: widget.tabItems[selectedPos].circleColor,
-            border: Border.all(width: widget.circleStrokeWidth, color: widget.barBackgroundColor)),
+        child: Stack(
+          children: <Widget>[
+            Container(
+              decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: widget.barBackgroundColor),
+            ),
+            Container(
+              margin: EdgeInsets.all(widget.circleStrokeWidth),
+              decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: widget.tabItems[selectedPos].circleColor),
+            ),
+          ],
+        ),
       ),
       left: (selectedPosAnimation.value * sectionsWidth) +
           (sectionsWidth / 2) -

--- a/lib/circular_bottom_navigation.dart
+++ b/lib/circular_bottom_navigation.dart
@@ -154,7 +154,7 @@ class _CircularBottomNavigationState extends State<CircularBottomNavigation>
         height: widget.circleSize,
         decoration: BoxDecoration(
             shape: BoxShape.circle,
-            color: widget.tabItems[selectedPos].color,
+            color: widget.tabItems[selectedPos].circleColor,
             border: Border.all(width: widget.circleStrokeWidth, color: widget.barBackgroundColor)),
       ),
       left: (selectedPosAnimation.value * sectionsWidth) +
@@ -204,7 +204,7 @@ class _CircularBottomNavigationState extends State<CircularBottomNavigation>
                 child: Text(
                   widget.tabItems[pos].title,
                   textAlign: TextAlign.center,
-                  style: TextStyle(fontWeight: FontWeight.bold, color: widget.tabItems[pos].color),
+                  style: widget.tabItems[pos].labelStyle,
                 ),
               )),
         ),

--- a/lib/tab_item.dart
+++ b/lib/tab_item.dart
@@ -2,7 +2,8 @@ import 'package:flutter/material.dart';
 class TabItem {
   IconData icon;
   String title;
-  Color color;
+  Color circleColor;
+  TextStyle labelStyle;
 
-  TabItem(this.icon, this.title, this.color);
+  TabItem(this.icon, this.title, this.circleColor, {this.labelStyle = const TextStyle(fontWeight: FontWeight.bold)});
 }


### PR DESCRIPTION
1. According to the artwork in [Uplabs ](https://www.uplabs.com/posts/bottom-tab) the icons must have no shadow and follow the flat colors.
So I removed it and you can see the changes here:
![Screenshot_2019-08-15-06-00-42](https://user-images.githubusercontent.com/8822586/63067239-35ddce00-bf23-11e9-8602-81baee5336ec.png)

2. I made changes so users can pass style for label of each `TabItem`, of course it is not `required` and there is some default style for when the user leaves it empty (Bold) . This feature is added to fix issue #6