### PR TITLE
Allows selected tab icon to execute its callback even if it's already selected.

### DIFF
--- a/lib/circular_bottom_navigation.dart
+++ b/lib/circular_bottom_navigation.dart
@@ -23,6 +23,10 @@ class CircularBottomNavigation extends StatefulWidget {
   final CircularBottomNavSelectedCallback? selectedCallback;
   final CircularBottomNavigationController? controller;
 
+  /// If true, allows a selected tab icon to execute its callback even if it's
+  /// already selected.
+  final bool allowSelectedIconCallback;
+
   CircularBottomNavigation(
     this.tabItems, {
     this.selectedPos = 0,
@@ -36,6 +40,7 @@ class CircularBottomNavigation extends StatefulWidget {
     this.animationDuration = const Duration(milliseconds: 300),
     this.selectedCallback,
     this.controller,
+    this.allowSelectedIconCallback = false,
     backgroundBoxShadow,
   })  : backgroundBoxShadow = backgroundBoxShadow ??
             [BoxShadow(color: Colors.grey, blurRadius: 2.0)],
@@ -289,6 +294,17 @@ class _CircularBottomNavigationState extends State<CircularBottomNavigation>
             rect: r,
           ),
         );
+      } else if (widget.allowSelectedIconCallback == true) {
+        Rect selectedRect = Rect.fromLTWH(r.left, 0, r.width, fullHeight);
+        children.add(
+          Positioned.fromRect(
+            child: ClipRRect(
+              borderRadius: BorderRadius.vertical(top: Radius.circular(40.0)),
+              child: GestureDetector(onTap: _selectedCallback),
+            ),
+            rect: selectedRect,
+          ),
+        );
       }
     });
 
@@ -310,6 +326,10 @@ class _CircularBottomNavigationState extends State<CircularBottomNavigation>
         previousSelectedPos!.toDouble(), selectedPos!.toDouble());
     selectedPosAnimation.addListener(onSelectedPosAnimate);
 
+    _selectedCallback();
+  }
+
+  void _selectedCallback() {
     if (widget.selectedCallback != null) {
       widget.selectedCallback!(selectedPos);
     }


### PR DESCRIPTION
closes #25 


Hitbox for tab icon when `allowSelectedIconCallback` is true is illustrated by green border as shown in image.
The default behavior was not modified.

<div align=center><img src="https://user-images.githubusercontent.com/11953552/195957312-cf0d41ae-6b79-4cf2-843b-317ee585bd26.png" width=500/></div>
